### PR TITLE
feat(app): add main core functions to work with client state

### DIFF
--- a/app/src/core.js
+++ b/app/src/core.js
@@ -1,0 +1,46 @@
+import {List, Map} from 'immutable';
+
+/* Not sure we need this function here. */
+export function intiateState() {
+  return Map({
+    channels: List(),
+    messages: List(),
+    users: List(),
+    user: Map(),
+  });
+}
+
+export function addChannel(state, channel) {
+  return state.updateIn(['channels'], List(), channels => channels.push(channel));
+}
+
+export function removeChannel(state, channelId) {
+  const index = state.get('channels').map(item => item.get('id')).indexOf(channelId);
+
+  return state.updateIn(['channels'], List(), channels => channels.delete(index));
+}
+
+export function addUserToChannel(state, channelId, userId) {
+  const index = state.get('channels').map(item => item.get('id')).indexOf(channelId);
+
+  return state.updateIn(['channels', index, 'userIds'], List(), userIds => userIds.push(userId) );
+}
+
+export function removeUserFromChannel(state, channelId, userId) {
+  const index = state.get('channels').map(item => item.get('id')).indexOf(channelId);
+
+  return state.updateIn(['channels', index, 'userIds'], List(), userIds => userIds.delete(userIds.indexOf(userId)));
+}
+
+export function addMessage(state, message) {
+  const channelId = message.get('channelId');
+  const index = state.get('channels').map(item => item.get('id')).indexOf(channelId);
+  return state
+    .updateIn(['channels', index, 'messageIds'], List(), messageIds => messageIds.push(message.get('id')))
+    .updateIn(['messages'], List(), messages => messages.push(message));
+
+}
+
+
+
+

--- a/app/src/core.js
+++ b/app/src/core.js
@@ -38,9 +38,4 @@ export function addMessage(state, message) {
   return state
     .updateIn(['channels', index, 'messageIds'], List(), messageIds => messageIds.push(message.get('id')))
     .updateIn(['messages'], List(), messages => messages.push(message));
-
 }
-
-
-
-

--- a/app/tests/core/test_core.js
+++ b/app/tests/core/test_core.js
@@ -1,0 +1,82 @@
+import {List, Map} from 'immutable';
+import {expect} from 'chai';
+import {addChannel, removeChannel, addUserToChannel, removeUserFromChannel, addMessage} from '../../src/core.js';
+
+describe('application logic', () => {
+
+  describe('addChannel', () => {
+    it('add new channel', () => {
+      const state = Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2)})),
+      });
+      const channel = Map({id: 1, name: '1', userIds: List.of(1, 2, 3) });
+      const nextState = addChannel(state, channel);
+      expect(nextState).to.equal(Map({
+        channels: List.of(
+          Map({id: 0, name: '0', userIds: List.of(1, 2) }),
+          Map({id: 1, name: '1', userIds: List.of(1, 2, 3) }),
+        ),
+      }));
+    });
+  });
+
+  describe('removeChannel', () => {
+    it('remove channel by id', () => {
+      const state = Map({
+        channels: List.of(
+          Map({id: 0, name: '0', userIds: List.of(1, 2) }),
+          Map({id: 1, name: '1', userIds: List.of(1, 2, 3) }),
+        ),
+      });
+      const channelId = 1;
+      const nextState = removeChannel(state, channelId);
+      expect(nextState).to.equal(Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2) })),
+      }));
+    });
+  });
+
+  describe('addUserToChannel', () => {
+    it('adds user\'s id to state\'s userIds', () => {
+      const state = Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2)})),
+      });
+      const channelId = 0;
+      const userId = 3;
+      const nextState = addUserToChannel(state, channelId, userId);
+      expect(nextState).to.equal(Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3) })),
+      }));
+    });
+  });
+
+  describe('removeUserFromChannel', () => {
+    it('remove user\'s id from state\'s userIds', () => {
+      const state = Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3) })),
+      });
+      const channelId = 0;
+      const userId = 2;
+      const nextState = removeUserFromChannel(state, channelId, userId);
+      expect(nextState).to.equal(Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 3) })),
+      }));
+    });
+  });
+
+  describe('addMessage', () => {
+    it('add message in messages store', () => {
+      const state = Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3), messageIds: List.of(123) })),
+        messages: List.of(Map({id: 123, channelId: 0, text: 'first comment'})),
+      });
+      const message = Map({id: 124, channelId: 0, text: 'second comment'});
+      const nextState = addMessage(state, message);
+      console.log(nextState);
+      expect(nextState).to.equal(Map({
+        channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3), messageIds: List.of(123, 124) })),
+        messages: List.of(Map({id: 123, channelId: 0, text: 'first comment'}), Map({id: 124, channelId: 0, text: 'second comment'}))
+      }));
+    });
+  });
+});

--- a/app/tests/core/test_core.js
+++ b/app/tests/core/test_core.js
@@ -3,7 +3,6 @@ import {expect} from 'chai';
 import {addChannel, removeChannel, addUserToChannel, removeUserFromChannel, addMessage} from '../../src/core.js';
 
 describe('application logic', () => {
-
   describe('addChannel', () => {
     it('add new channel', () => {
       const state = Map({
@@ -75,7 +74,7 @@ describe('application logic', () => {
       console.log(nextState);
       expect(nextState).to.equal(Map({
         channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3), messageIds: List.of(123, 124) })),
-        messages: List.of(Map({id: 123, channelId: 0, text: 'first comment'}), Map({id: 124, channelId: 0, text: 'second comment'}))
+        messages: List.of(Map({id: 123, channelId: 0, text: 'first comment'}), Map({id: 124, channelId: 0, text: 'second comment'})),
       }));
     });
   });

--- a/app/tests/core/test_core.js
+++ b/app/tests/core/test_core.js
@@ -71,7 +71,6 @@ describe('application logic', () => {
       });
       const message = Map({id: 124, channelId: 0, text: 'second comment'});
       const nextState = addMessage(state, message);
-      console.log(nextState);
       expect(nextState).to.equal(Map({
         channels: List.of(Map({id: 0, name: '0', userIds: List.of(1, 2, 3), messageIds: List.of(123, 124) })),
         messages: List.of(Map({id: 123, channelId: 0, text: 'first comment'}), Map({id: 124, channelId: 0, text: 'second comment'})),

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
     "immutable": "^3.7.5",
-    "jsdom": "^6.3.0",
+    "jsdom": "^3.1.2",
     "mocha": "^2.3.2",
     "pre-commit": "^1.1.1",
     "react-addons": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
     "immutable": "^3.7.5",
-    "jsdom": "^3.1.5",
+    "jsdom": "^4.0.0",
     "mocha": "^2.3.2",
     "pre-commit": "^1.1.1",
     "react-addons": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "lint": "./node_modules/.bin/eslint --ext .js --ext .jsx app/ server/; exit 0",
     "test-server": "./node_modules/.bin/mocha --compilers js:babel/register --require ./server/test/test_helper.js --recursive ./server/test/test_core.js",
     "test-client": "./node_modules/.bin/mocha --compilers js:babel/register --require ./app/tests/test_helper.js --recursive ./app/tests/core/test_core.js",
-    "test": "npm run test-server && npm run lint",
+    "test": "npm run test-server && npm run test-client && npm run lint",
     "webpack": "NODE_ENV=production webpack --config webpack-production.config.js --progress --profile --colors",
     "webpack-dev": "webpack-dev-server --config webpack-dev.config.js",
     "server-dev": "NODE_ENV=development NODE_PATH=./node_modules:./app babel-node server/server",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
     "immutable": "^3.7.5",
-    "jsdom": "^4.0.0",
+    "jsdom": "^6.3.0",
     "mocha": "^2.3.2",
     "pre-commit": "^1.1.1",
     "react-addons": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "eslint-config-airbnb": "0.0.8",
     "eslint-plugin-react": "^3.3.2",
     "immutable": "^3.7.5",
-    "jsdom": "^6.3.0",
+    "jsdom": "^3.1.5",
     "mocha": "^2.3.2",
     "pre-commit": "^1.1.1",
     "react-addons": "^0.9.0",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "scripts": {
     "lint": "./node_modules/.bin/eslint --ext .js --ext .jsx app/ server/; exit 0",
     "test-server": "./node_modules/.bin/mocha --compilers js:babel/register --require ./server/test/test_helper.js --recursive ./server/test/test_core.js",
+    "test-client": "./node_modules/.bin/mocha --compilers js:babel/register --require ./app/tests/test_helper.js --recursive ./app/tests/core/test_core.js",
     "test": "npm run test-server && npm run lint",
     "webpack": "NODE_ENV=production webpack --config webpack-production.config.js --progress --profile --colors",
     "webpack-dev": "webpack-dev-server --config webpack-dev.config.js",


### PR DESCRIPTION
Add main core functions to work with client state: `initiateState`, `addChannel`, `removeChannel`, `addUserToChannel`, `removeUserFromChannel`, `addMessage`.

Test included.

#2