### PR TITLE
task: improve loading of messages

### DIFF
--- a/app/core/socket.js
+++ b/app/core/socket.js
@@ -5,7 +5,7 @@ import * as channelActions from '../actions/channels';
 import * as messageActions from '../actions/messages';
 import {setUserInfo, joinUser} from 'actions/users';
 import {init, initUser, logOut} from '../actions/local';
-import {SC} from '../../constants';
+import {S, SC} from '../../constants';
 
 
 export function socketClient(type = null, socketData) {
@@ -51,7 +51,7 @@ export function socketClient(type = null, socketData) {
       store.dispatch(messageActions.setChannelHistory(data));
       // When we receive less messages then expected, it means that there are no
       // more messages on the server for this channel, so we should should stop waiting.
-      const status = data.messages.length === 20 ? data.messages[data.messages.length - 1].timestamp : 'END';
+      const status = data.messages.length === S.NUMBER_OF_MESSAGES_PER_LOAD ? data.messages[data.messages.length - 1].timestamp : 'END';
       store.dispatch(channelActions.setLoadingStatus({channelId: data.messages[data.messages.length - 1].channelId, status}));
     });
 

--- a/constants.js
+++ b/constants.js
@@ -1,3 +1,4 @@
+// Server to client actions
 const SC = {
   ADD_MESSAGE: 'SC_ADD_MESSAGE',
   ADD_CHANNEL: 'SC_ADD_CHANNEL',
@@ -11,6 +12,7 @@ const SC = {
   ADD_DIRECT_CHANNEL: 'SC_ADD_DIRECT_CHANNEL',
 };
 
+// Client to server actions
 const CS = {
   ADD_MESSAGE: 'CS_ADD_MESSAGE',
   ADD_CHANNEL: 'CS_ADD_CHANNEL',
@@ -25,6 +27,7 @@ const CS = {
   ADD_DIRECT_CHANNEL: 'CS_ADD_DIRECT_CHANNEL',
 };
 
+// Local actions
 const A = {
   ADD_MESSAGE: 'ADD_MESSAGE',
   REMOVE_CHANNEL: 'REMOVE_CHANNEL',
@@ -49,8 +52,14 @@ const A = {
   SET_LOADING_STATUS: 'SET_LOADING_STATUS',
 };
 
+// System-wide settings
+const S = {
+  NUMBER_OF_MESSAGES_PER_LOAD: 5,
+};
+
 module.exports = {
   SC: SC,
   CS: CS,
   A: A,
+  S: S,
 };

--- a/server/db/db_core.js
+++ b/server/db/db_core.js
@@ -4,6 +4,7 @@ import crypto from 'crypto';
 import getUserModel from '../models/user';
 import getChannelModel from '../models/channel';
 import getMessageModel from '../models/message';
+import {S} from '../../constants';
 
 const ObjectId = mongoose.Types.ObjectId;
 const Channel = getChannelModel();
@@ -175,7 +176,7 @@ export function loadChannelHistory(channelId, baseDate = null, callback) {
     timestamp: {
       $lt: date,
     },
-  }).sort('-timestamp').limit(20).exec((error, messages) => {
+  }).sort('-timestamp').limit(S.NUMBER_OF_MESSAGES_PER_LOAD).exec((error, messages) => {
     if (error) debug(error);
     callback(messages);
   });


### PR DESCRIPTION
Veged has found an edgecase: if messages loaded at first load would fit
into first screen, no scrollbar would appear, so it would not be
possible to load more messages.

This commit fixes it and also improves the loading of messages.
Also the number of loaded messages is extracted to constants.